### PR TITLE
Add scene system with intro and gameplay scenes

### DIFF
--- a/src/engine/game_state.h
+++ b/src/engine/game_state.h
@@ -19,7 +19,8 @@
 #include "../game/player.h"
 #include "../game/star_particle.h"
 
-typedef struct Platform Platform;
+typedef struct Platform  Platform;
+typedef enum   SceneType SceneType;
 
 /*
  * Game State
@@ -35,6 +36,7 @@ typedef struct GameState {
     CF_Arena     scratch_arena;
     CF_DisplayID display_id;
     CF_Rnd       rnd;
+    SceneType    current_scene;
     int          score;
     int          lives;
 

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -18,6 +18,9 @@ add_library(
     star_particle.c
     sprite.c
     background_scroll.c
+    scene.c
+    scene/intro.c
+    scene/gameplay.c
     game.c
 )
 target_link_libraries(${NAME}

--- a/src/game/game.c
+++ b/src/game/game.c
@@ -36,6 +36,7 @@
 #include "movement.h"
 #include "player.h"
 #include "render.h"
+#include "scene.h"
 #include "sprite.h"
 #include "star_particle.h"
 
@@ -134,263 +135,30 @@ EXPORT void game_init(Platform* platform) {
     init_star_particles();
 
     cf_music_play(g_state->audio.music, 0.5f);
+
+    // Initialize the intro scene
+    scene_init(SCENE_INTRO);
 }
 
 EXPORT bool game_update(void) {
     cf_arena_reset(&g_state->scratch_arena);
-
-    auto canvas_aabb = cf_make_aabb_center_half_extents(cf_v2(0, 0), cf_div_v2_f(g_state->canvas_size, 2.0f));
 
 #ifdef DEBUG
     // Toggle debug mode
     if (cf_key_just_pressed(CF_KEY_G)) g_state->debug = !g_state->debug;
 #endif
 
-    update_input(&g_state->player.input);
-
-    // Handle game over state
-    if (g_state->is_game_over) {
-        // Check for restart input (shoot button)
-        if (g_state->player.input.shoot) {
-            // TODO: Extract a generic init/reset function
-            // Reset game state
-            g_state->is_game_over          = false;
-            g_state->lives                 = 3;
-            g_state->score                 = 0;
-
-            // Reset player
-            g_state->player                = make_player(0.0f, -g_state->canvas_size.y / 3);
-            g_state->player_bullets_count  = 0;
-            g_state->enemies_count         = 0;
-            g_state->enemy_bullets_count   = 0;
-            g_state->explosions_count      = 0;
-            g_state->hit_particles_count   = 0;
-            g_state->star_particles_count  = 0;
-            g_state->floating_scores_count = 0;
-
-            // Re-initialize star particles
-            init_star_particles();
-
-            // Restart coroutines
-            cleanup_coroutines();
-            init_coroutines();
-        }
-        return true;
-    }
-    update_player(&g_state->player);
-    // Update player movement
-    update_movement(&g_state->player.position, &g_state->player.velocity);
-
-    // Update player bullets
-    for (size_t i = 0; i < g_state->player_bullets_count; i++) {
-        update_movement(&g_state->player_bullets[i].position, &g_state->player_bullets[i].velocity);
-
-        // Mark bullet as destroyed when out of screen bounds
-        if (g_state->player_bullets[i].position.y > g_state->canvas_size.y * 0.5f) {
-            g_state->player_bullets[i].is_alive = false;
-        }
-    }
-    // Update enemies
-    for (size_t i = 0; i < g_state->enemies_count; i++) {
-        update_movement(&g_state->enemies[i].position, &g_state->enemies[i].velocity);
-        update_enemy(&g_state->enemies[i]);  // TODO: Rename to update_enemy_weapon
-
-        // Mark enemy as destroyed when out of screen bounds
-        auto enemy_aabb =
-            cf_make_aabb_center_half_extents(g_state->enemies[i].position, g_state->enemies[i].collider.half_extents);
-        if (!cf_aabb_to_aabb(canvas_aabb, enemy_aabb)) { g_state->enemies[i].is_alive = false; }
-    }
-    // Update enemy bullets
-    for (size_t i = 0; i < g_state->enemy_bullets_count; i++) {
-        update_movement(&g_state->enemy_bullets[i].position, &g_state->enemy_bullets[i].velocity);
-
-        // Mark bullet as destroyed when out of screen bounds
-        auto bullet_aabb = cf_make_aabb_center_half_extents(
-            g_state->enemy_bullets[i].position, g_state->enemy_bullets[i].collider.half_extents
-        );
-        if (!cf_aabb_to_aabb(canvas_aabb, bullet_aabb)) { g_state->enemy_bullets[i].is_alive = false; }
-    }
-    // Update hit particles
-    for (size_t i = 0; i < g_state->hit_particles_count; i++) {
-        update_movement(&g_state->hit_particles[i].position, &g_state->hit_particles[i].velocity);
-
-        // Mark particle as destroyed when out of screen bounds
-        if (g_state->hit_particles[i].position.x < canvas_aabb.min.x ||
-            g_state->hit_particles[i].position.x > canvas_aabb.max.x ||
-            g_state->hit_particles[i].position.y < canvas_aabb.min.y ||
-            g_state->hit_particles[i].position.y > canvas_aabb.max.y) {
-            g_state->hit_particles[i].is_alive = false;
-        }
-    }
-    update_particles();
-    update_star_particles();
-    update_floating_scores();
-
-    // TODO: Decide where to move this
-    // Clamp player position to canvas bounds
-    g_state->player.position.x =
-        cf_clamp(g_state->player.position.x, -g_state->canvas_size.x / 2.0f, g_state->canvas_size.x / 2.0f);
-    g_state->player.position.y =
-        cf_clamp(g_state->player.position.y, -g_state->canvas_size.y / 2.0f, g_state->canvas_size.y / 2.0f);
-
-    update_background_scroll();
-    update_collision();
-    update_coroutine();
-
-    cleanup_enemies();
-    cleanup_enemy_bullets();
-    cleanup_explosions();
-    cleanup_hit_particles();
-    cleanup_player_bullets();
-    cleanup_floating_scores();
+    // Delegate to current scene
+    Scene current_scene = scene_get_current();
+    if (current_scene.update) { return current_scene.update(); }
 
     return true;
 }
 
-static void game_render_debug(void) {
-    auto weapon = &g_state->player.weapon;
-    auto pos    = &g_state->player.position;
-    auto vel    = &g_state->player.velocity;
-    auto input  = &g_state->player.input;
-
-    ImGui_Begin("Debug Menu", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
-    {
-        if (ImGui_CollapsingHeader("Debug", true)) {
-            ImGui_Checkbox("Draw Bounding Boxes", &g_state->debug_bounding_boxes);
-        }
-
-        if (ImGui_CollapsingHeader("Player", true)) {
-            ImGui_Text("Position: (%.2f, %.2f)", pos->x, pos->y);
-            ImGui_Text("Velocity: (%.2f, %.2f)", vel->x, vel->y);
-            ImGui_Text("Up: %s", input->up ? "Y" : "N");
-            ImGui_Text("Down: %s", input->down ? "Y" : "N");
-            ImGui_Text("Left: %s", input->left ? "Y" : "N");
-            ImGui_Text("Right: %s", input->right ? "Y" : "N");
-            ImGui_Text("Shoot: %s", input->shoot ? "Y" : "N");
-        }
-
-        if (ImGui_CollapsingHeader("Entity Counts", true)) {
-            ImGui_Text("Enemies: %zu", g_state->enemies_count);
-            ImGui_Text("EnemyBullets: %zu", g_state->enemy_bullets_count);
-            ImGui_Text("Explosions: %zu", g_state->explosions_count);
-            ImGui_Text("HitParticles: %zu", g_state->hit_particles_count);
-            ImGui_Text("PlayerBullets: %zu", g_state->player_bullets_count);
-        }
-
-        if (ImGui_CollapsingHeader("Weapon", true)) {
-            ImGui_DragFloat("Cooldown", &weapon->cooldown);
-            ImGui_Text("Time Since Last Shot: %.2f", weapon->time_since_shot);
-        }
-
-        if (ImGui_CollapsingHeader("Performance", true)) { ImGui_Text("FPS: %.2f", cf_app_get_framerate()); }
-
-        if (ImGui_CollapsingHeader("Window", true)) {
-            ImGui_Text("Screen: %dx%d", cf_display_width(g_state->display_id), cf_display_height(g_state->display_id));
-            ImGui_Text("Size: %dx%d", cf_app_get_width(), cf_app_get_height());
-            ImGui_Text("Canvas: %dx%d", cf_app_get_canvas_width(), cf_app_get_canvas_height());
-            ImGui_Text("Canvas(logical): %.0fx%.0f", g_state->canvas_size.x, g_state->canvas_size.y);
-            ImGui_Text("Game Scale: %.2f", g_state->scale);
-            ImGui_Text("DPI Scale: %.2f", cf_app_get_dpi_scale());
-        }
-    }
-    ImGui_End();
-
-    if (g_state->debug_bounding_boxes) {
-        // Draw on top of everything
-        cf_draw_layer(Z_MAX) {
-            RENDER_DEBUG_BBOXES(g_state->enemies, g_state->enemies_count, position, collider);
-            RENDER_DEBUG_BBOXES(g_state->player_bullets, g_state->player_bullets_count, position, collider);
-            RENDER_DEBUG_BBOXES(g_state->enemy_bullets, g_state->enemy_bullets_count, position, collider);
-            {
-                auto entity        = &g_state->player;
-                auto aabb_collider = cf_make_aabb_center_half_extents(entity->position, entity->collider.half_extents);
-
-                cf_draw() {
-                    cf_draw_color(cf_color_blue()) { cf_draw_quad(aabb_collider, 0, 0); }
-                }
-            }
-        }
-    }
-}
-
 EXPORT void game_render(void) {
-#ifdef DEBUG
-    if (g_state->debug) game_render_debug();
-#endif
-
-    render_background_scroll();
-    render_star_particles();
-
-    // Show game over screen
-    if (g_state->is_game_over) {
-        cf_draw() {
-            cf_draw_layer(Z_UI) {
-                // Draw game over sprite centered
-                cf_draw_sprite(&g_state->sprites.game_over);
-            }
-        }
-
-        return;
-    }
-
-    render_player(&g_state->player);
-    RENDER_ENTITY_ARRAY(g_state->enemies, g_state->enemies_count, sprite, position, z_index);
-    RENDER_ENTITY_ARRAY(g_state->enemy_bullets, g_state->enemy_bullets_count, sprite, position, z_index);
-    RENDER_ENTITY_ARRAY(g_state->explosions, g_state->explosions_count, sprite, position, z_index);
-    RENDER_ENTITY_ARRAY(g_state->player_bullets, g_state->player_bullets_count, sprite, position, z_index);
-
-    // Custom code for particles draw
-    for (size_t i = 0; i < g_state->hit_particles_count; i++) {
-        cf_draw() {
-            cf_draw_layer(Z_PARTICLES) {
-                cf_draw_translate_v2(g_state->hit_particles[i].position);
-                cf_draw_scale(g_state->hit_particles[i].size, g_state->hit_particles[i].size);
-                cf_draw_sprite(&g_state->hit_particles[i].sprite);
-            }
-        }
-    }
-
-    render_floating_scores();
-
-    // Render UI
-    char score_text[6 + 1];
-
-    cf_draw() {
-        cf_font("TinyAndChunky") {
-            cf_push_font_size(7);
-            snprintf(score_text, 7, "%06d", g_state->score);
-            float     text_width   = cf_text_width(score_text, -1);
-            float     text_height  = cf_text_height(score_text, -1);
-            float     offset_x     = (float)cf_app_get_canvas_width() / 2 / g_state->scale - text_width;
-            float     offset_y     = (float)cf_app_get_canvas_height() / 2 / g_state->scale + text_height / 2;
-            const int margin_top   = 4;
-            const int margin_right = 4;
-
-            cf_draw_color(cf_make_color_rgb(20, 91, 132)) {
-                cf_draw_text(score_text, cf_v2(offset_x + 1 - margin_right, offset_y - 1 - margin_top), -1);
-            }
-            cf_draw_color(cf_color_white()) {
-                cf_draw_text(score_text, cf_v2(offset_x - margin_right, offset_y - margin_top), -1);
-            }
-        }
-
-        // Render life icons
-        const int icon_margin_right  = 4;
-        const int icon_margin_bottom = 4;
-        float     icon_width         = (float)g_state->sprites.life_icon.w;
-        float     icon_height        = (float)g_state->sprites.life_icon.h;
-        float     canvas_half_width  = (float)cf_app_get_canvas_width() / 2 / g_state->scale;
-        float     canvas_half_height = (float)cf_app_get_canvas_height() / 2 / g_state->scale;
-
-        for (int i = 0; i < g_state->lives; i++) {
-            float x = canvas_half_width - icon_margin_right - (i + 1) * (icon_width) + icon_width / 2;
-            float y = -canvas_half_height + icon_margin_bottom + icon_height / 4;
-            cf_draw() {
-                cf_draw_translate_v2(cf_v2(x, y));
-                cf_draw_sprite(&g_state->sprites.life_icon);
-            }
-        }
-    }
+    // Delegate to current scene
+    Scene current_scene = scene_get_current();
+    if (current_scene.render) { current_scene.render(); }
 }
 
 EXPORT void game_shutdown(void) {

--- a/src/game/scene.c
+++ b/src/game/scene.c
@@ -1,0 +1,35 @@
+#include "scene.h"
+
+#include "../engine/game_state.h"
+#include "scene/gameplay.h"
+#include "scene/intro.h"
+
+static Scene current_scene;
+
+void scene_init(SceneType type) {
+    g_state->current_scene = type;
+
+    switch (type) {
+        case SCENE_INTRO:
+            current_scene.init    = intro_init;
+            current_scene.update  = intro_update;
+            current_scene.render  = intro_render;
+            current_scene.cleanup = intro_cleanup;
+            break;
+        case SCENE_GAMEPLAY:
+            current_scene.init    = gameplay_init;
+            current_scene.update  = gameplay_update;
+            current_scene.render  = gameplay_render;
+            current_scene.cleanup = gameplay_cleanup;
+            break;
+    }
+
+    if (current_scene.init) { current_scene.init(); }
+}
+
+void scene_switch(SceneType type) {
+    if (current_scene.cleanup) { current_scene.cleanup(); }
+    scene_init(type);
+}
+
+Scene scene_get_current(void) { return current_scene; }

--- a/src/game/scene.h
+++ b/src/game/scene.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <stdbool.h>
+
+// Scene types
+typedef enum SceneType {
+    SCENE_INTRO,
+    SCENE_GAMEPLAY,
+} SceneType;
+
+// Scene interface
+typedef struct Scene {
+    void (*init)(void);
+    bool (*update)(void);
+    void (*render)(void);
+    void (*cleanup)(void);
+} Scene;
+
+// Scene management functions
+void  scene_init(SceneType type);
+void  scene_switch(SceneType type);
+Scene scene_get_current(void);

--- a/src/game/scene/gameplay.c
+++ b/src/game/scene/gameplay.c
@@ -1,0 +1,285 @@
+#include "gameplay.h"
+
+#include <cute_alloc.h>
+#include <cute_app.h>
+#include <cute_audio.h>
+#include <cute_draw.h>
+#include <cute_math.h>
+#include <dcimgui.h>
+#include <stdio.h>
+
+#include "../../engine/cute_macros.h"
+#include "../../engine/game_state.h"
+#include "../../engine/log.h"
+#include "../background_scroll.h"
+#include "../collision.h"
+#include "../component.h"
+#include "../coroutine.h"
+#include "../enemy.h"
+#include "../explosion.h"
+#include "../floating_score.h"
+#include "../hit_particle.h"
+#include "../input.h"
+#include "../movement.h"
+#include "../player.h"
+#include "../render.h"
+#include "../star_particle.h"
+
+void gameplay_init(void) {
+    // Initialize gameplay scene
+    // Most initialization is already done in game_init, but we can add scene-specific init here
+}
+
+bool gameplay_update(void) {
+    auto canvas_aabb = cf_make_aabb_center_half_extents(cf_v2(0, 0), cf_div_v2_f(g_state->canvas_size, 2.0f));
+
+    update_input(&g_state->player.input);
+
+    // Handle game over state
+    if (g_state->is_game_over) {
+        // Check for restart input (shoot button)
+        if (g_state->player.input.shoot) {
+            // TODO: Extract a generic init/reset function
+            // Reset game state
+            g_state->is_game_over          = false;
+            g_state->lives                 = 3;
+            g_state->score                 = 0;
+
+            // Reset player
+            g_state->player                = make_player(0.0f, -g_state->canvas_size.y / 3);
+            g_state->player_bullets_count  = 0;
+            g_state->enemies_count         = 0;
+            g_state->enemy_bullets_count   = 0;
+            g_state->explosions_count      = 0;
+            g_state->hit_particles_count   = 0;
+            g_state->star_particles_count  = 0;
+            g_state->floating_scores_count = 0;
+
+            // Re-initialize star particles
+            init_star_particles();
+
+            // Restart coroutines
+            cleanup_coroutines();
+            init_coroutines();
+        }
+        return true;
+    }
+    update_player(&g_state->player);
+    // Update player movement
+    update_movement(&g_state->player.position, &g_state->player.velocity);
+
+    // Update player bullets
+    for (size_t i = 0; i < g_state->player_bullets_count; i++) {
+        update_movement(&g_state->player_bullets[i].position, &g_state->player_bullets[i].velocity);
+
+        // Mark bullet as destroyed when out of screen bounds
+        if (g_state->player_bullets[i].position.y > g_state->canvas_size.y * 0.5f) {
+            g_state->player_bullets[i].is_alive = false;
+        }
+    }
+    // Update enemies
+    for (size_t i = 0; i < g_state->enemies_count; i++) {
+        update_movement(&g_state->enemies[i].position, &g_state->enemies[i].velocity);
+        update_enemy(&g_state->enemies[i]);  // TODO: Rename to update_enemy_weapon
+
+        // Mark enemy as destroyed when out of screen bounds
+        auto enemy_aabb =
+            cf_make_aabb_center_half_extents(g_state->enemies[i].position, g_state->enemies[i].collider.half_extents);
+        if (!cf_aabb_to_aabb(canvas_aabb, enemy_aabb)) { g_state->enemies[i].is_alive = false; }
+    }
+    // Update enemy bullets
+    for (size_t i = 0; i < g_state->enemy_bullets_count; i++) {
+        update_movement(&g_state->enemy_bullets[i].position, &g_state->enemy_bullets[i].velocity);
+
+        // Mark bullet as destroyed when out of screen bounds
+        auto bullet_aabb = cf_make_aabb_center_half_extents(
+            g_state->enemy_bullets[i].position, g_state->enemy_bullets[i].collider.half_extents
+        );
+        if (!cf_aabb_to_aabb(canvas_aabb, bullet_aabb)) { g_state->enemy_bullets[i].is_alive = false; }
+    }
+    // Update hit particles
+    for (size_t i = 0; i < g_state->hit_particles_count; i++) {
+        update_movement(&g_state->hit_particles[i].position, &g_state->hit_particles[i].velocity);
+
+        // Mark particle as destroyed when out of screen bounds
+        if (g_state->hit_particles[i].position.x < canvas_aabb.min.x ||
+            g_state->hit_particles[i].position.x > canvas_aabb.max.x ||
+            g_state->hit_particles[i].position.y < canvas_aabb.min.y ||
+            g_state->hit_particles[i].position.y > canvas_aabb.max.y) {
+            g_state->hit_particles[i].is_alive = false;
+        }
+    }
+    update_particles();
+    update_star_particles();
+    update_floating_scores();
+
+    // TODO: Decide where to move this
+    // Clamp player position to canvas bounds
+    g_state->player.position.x =
+        cf_clamp(g_state->player.position.x, -g_state->canvas_size.x / 2.0f, g_state->canvas_size.x / 2.0f);
+    g_state->player.position.y =
+        cf_clamp(g_state->player.position.y, -g_state->canvas_size.y / 2.0f, g_state->canvas_size.y / 2.0f);
+
+    update_background_scroll();
+    update_collision();
+    update_coroutine();
+
+    cleanup_enemies();
+    cleanup_enemy_bullets();
+    cleanup_explosions();
+    cleanup_hit_particles();
+    cleanup_player_bullets();
+    cleanup_floating_scores();
+
+    return true;
+}
+
+static void gameplay_render_debug(void) {
+    auto weapon = &g_state->player.weapon;
+    auto pos    = &g_state->player.position;
+    auto vel    = &g_state->player.velocity;
+    auto input  = &g_state->player.input;
+
+    ImGui_Begin("Debug Menu", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
+    {
+        if (ImGui_CollapsingHeader("Debug", true)) {
+            ImGui_Checkbox("Draw Bounding Boxes", &g_state->debug_bounding_boxes);
+        }
+
+        if (ImGui_CollapsingHeader("Player", true)) {
+            ImGui_Text("Position: (%.2f, %.2f)", pos->x, pos->y);
+            ImGui_Text("Velocity: (%.2f, %.2f)", vel->x, vel->y);
+            ImGui_Text("Up: %s", input->up ? "Y" : "N");
+            ImGui_Text("Down: %s", input->down ? "Y" : "N");
+            ImGui_Text("Left: %s", input->left ? "Y" : "N");
+            ImGui_Text("Right: %s", input->right ? "Y" : "N");
+            ImGui_Text("Shoot: %s", input->shoot ? "Y" : "N");
+        }
+
+        if (ImGui_CollapsingHeader("Entity Counts", true)) {
+            ImGui_Text("Enemies: %zu", g_state->enemies_count);
+            ImGui_Text("EnemyBullets: %zu", g_state->enemy_bullets_count);
+            ImGui_Text("Explosions: %zu", g_state->explosions_count);
+            ImGui_Text("HitParticles: %zu", g_state->hit_particles_count);
+            ImGui_Text("PlayerBullets: %zu", g_state->player_bullets_count);
+        }
+
+        if (ImGui_CollapsingHeader("Weapon", true)) {
+            ImGui_DragFloat("Cooldown", &weapon->cooldown);
+            ImGui_Text("Time Since Last Shot: %.2f", weapon->time_since_shot);
+        }
+
+        if (ImGui_CollapsingHeader("Performance", true)) { ImGui_Text("FPS: %.2f", cf_app_get_framerate()); }
+
+        if (ImGui_CollapsingHeader("Window", true)) {
+            ImGui_Text("Screen: %dx%d", cf_display_width(g_state->display_id), cf_display_height(g_state->display_id));
+            ImGui_Text("Size: %dx%d", cf_app_get_width(), cf_app_get_height());
+            ImGui_Text("Canvas: %dx%d", cf_app_get_canvas_width(), cf_app_get_canvas_height());
+            ImGui_Text("Canvas(logical): %.0fx%.0f", g_state->canvas_size.x, g_state->canvas_size.y);
+            ImGui_Text("Game Scale: %.2f", g_state->scale);
+            ImGui_Text("DPI Scale: %.2f", cf_app_get_dpi_scale());
+        }
+    }
+    ImGui_End();
+
+    if (g_state->debug_bounding_boxes) {
+        // Draw on top of everything
+        cf_draw_layer(Z_MAX) {
+            RENDER_DEBUG_BBOXES(g_state->enemies, g_state->enemies_count, position, collider);
+            RENDER_DEBUG_BBOXES(g_state->player_bullets, g_state->player_bullets_count, position, collider);
+            RENDER_DEBUG_BBOXES(g_state->enemy_bullets, g_state->enemy_bullets_count, position, collider);
+            {
+                auto entity        = &g_state->player;
+                auto aabb_collider = cf_make_aabb_center_half_extents(entity->position, entity->collider.half_extents);
+
+                cf_draw() {
+                    cf_draw_color(cf_color_blue()) { cf_draw_quad(aabb_collider, 0, 0); }
+                }
+            }
+        }
+    }
+}
+
+void gameplay_render(void) {
+#ifdef DEBUG
+    if (g_state->debug) gameplay_render_debug();
+#endif
+
+    render_background_scroll();
+    render_star_particles();
+
+    // Show game over screen
+    if (g_state->is_game_over) {
+        cf_draw() {
+            cf_draw_layer(Z_UI) {
+                // Draw game over sprite centered
+                cf_draw_sprite(&g_state->sprites.game_over);
+            }
+        }
+
+        return;
+    }
+
+    render_player(&g_state->player);
+    RENDER_ENTITY_ARRAY(g_state->enemies, g_state->enemies_count, sprite, position, z_index);
+    RENDER_ENTITY_ARRAY(g_state->enemy_bullets, g_state->enemy_bullets_count, sprite, position, z_index);
+    RENDER_ENTITY_ARRAY(g_state->explosions, g_state->explosions_count, sprite, position, z_index);
+    RENDER_ENTITY_ARRAY(g_state->player_bullets, g_state->player_bullets_count, sprite, position, z_index);
+
+    // Custom code for particles draw
+    for (size_t i = 0; i < g_state->hit_particles_count; i++) {
+        cf_draw() {
+            cf_draw_layer(Z_PARTICLES) {
+                cf_draw_translate_v2(g_state->hit_particles[i].position);
+                cf_draw_scale(g_state->hit_particles[i].size, g_state->hit_particles[i].size);
+                cf_draw_sprite(&g_state->hit_particles[i].sprite);
+            }
+        }
+    }
+
+    render_floating_scores();
+
+    // Render UI
+    char score_text[6 + 1];
+
+    cf_draw() {
+        cf_font("TinyAndChunky") {
+            cf_push_font_size(7);
+            snprintf(score_text, 7, "%06d", g_state->score);
+            float     text_width   = cf_text_width(score_text, -1);
+            float     text_height  = cf_text_height(score_text, -1);
+            float     offset_x     = (float)cf_app_get_canvas_width() / 2 / g_state->scale - text_width;
+            float     offset_y     = (float)cf_app_get_canvas_height() / 2 / g_state->scale + text_height / 2;
+            const int margin_top   = 4;
+            const int margin_right = 4;
+
+            cf_draw_color(cf_make_color_rgb(20, 91, 132)) {
+                cf_draw_text(score_text, cf_v2(offset_x + 1 - margin_right, offset_y - 1 - margin_top), -1);
+            }
+            cf_draw_color(cf_color_white()) {
+                cf_draw_text(score_text, cf_v2(offset_x - margin_right, offset_y - margin_top), -1);
+            }
+        }
+
+        // Render life icons
+        const int icon_margin_right  = 4;
+        const int icon_margin_bottom = 4;
+        float     icon_width         = (float)g_state->sprites.life_icon.w;
+        float     icon_height        = (float)g_state->sprites.life_icon.h;
+        float     canvas_half_width  = (float)cf_app_get_canvas_width() / 2 / g_state->scale;
+        float     canvas_half_height = (float)cf_app_get_canvas_height() / 2 / g_state->scale;
+
+        for (int i = 0; i < g_state->lives; i++) {
+            float x = canvas_half_width - icon_margin_right - (i + 1) * (icon_width) + icon_width / 2;
+            float y = -canvas_half_height + icon_margin_bottom + icon_height / 4;
+            cf_draw() {
+                cf_draw_translate_v2(cf_v2(x, y));
+                cf_draw_sprite(&g_state->sprites.life_icon);
+            }
+        }
+    }
+}
+
+void gameplay_cleanup(void) {
+    // Cleanup gameplay scene resources here
+}

--- a/src/game/scene/gameplay.h
+++ b/src/game/scene/gameplay.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdbool.h>
+
+void gameplay_init(void);
+bool gameplay_update(void);
+void gameplay_render(void);
+void gameplay_cleanup(void);

--- a/src/game/scene/intro.c
+++ b/src/game/scene/intro.c
@@ -1,0 +1,54 @@
+#include "intro.h"
+
+#include <cute_app.h>
+#include <cute_draw.h>
+
+#include "../../engine/cute_macros.h"
+#include "../../engine/game_state.h"
+#include "../input.h"
+#include "../render.h"
+#include "../scene.h"
+
+void intro_init(void) {
+    // Initialize intro scene resources here
+}
+
+bool intro_update(void) {
+    update_input(&g_state->player.input);
+
+    // Transition to gameplay when shoot button is pressed
+    if (g_state->player.input.shoot) {
+        scene_switch(SCENE_GAMEPLAY);
+        return true;
+    }
+
+    return true;
+}
+
+void intro_render(void) {
+    cf_draw() {
+        cf_draw_layer(Z_UI) {
+            cf_font("TinyAndChunky") {
+                cf_push_font_size(12);
+
+                const char* text         = "INTRO";
+                float       text_width   = cf_text_width(text, -1);
+                float       text_height  = cf_text_height(text, -1);
+                float       center_x     = -text_width / 2;
+                float       center_y     = text_height / 2;
+
+                // Draw text with shadow
+                cf_draw_color(cf_make_color_rgb(20, 91, 132)) {
+                    cf_draw_text(text, cf_v2(center_x + 1, center_y - 1), -1);
+                }
+                cf_draw_color(cf_color_white()) {
+                    cf_draw_text(text, cf_v2(center_x, center_y), -1);
+                }
+            }
+        }
+    }
+}
+
+void intro_cleanup(void) {
+    // Cleanup intro scene resources here
+}

--- a/src/game/scene/intro.h
+++ b/src/game/scene/intro.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdbool.h>
+
+void intro_init(void);
+bool intro_update(void);
+void intro_render(void);
+void intro_cleanup(void);


### PR DESCRIPTION
This commit introduces a flexible scene system that allows the game to manage different states (intro, gameplay, etc.) with separate initialization, update, and render logic.

Changes:
- Created scene management system (scene.c/h) with scene switching
- Added intro scene that displays "INTRO" text and transitions to gameplay
- Moved existing game logic to gameplay scene
- Updated GameState to track current scene
- Refactored game.c to delegate to current scene's update/render
- Added new scene files to CMakeLists.txt

The intro scene currently displays simple text, with plans to add animated sprites in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)